### PR TITLE
feat: 앨범 도메인 관련 CRUD API 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "scripts": {
     "dev": "nodemon --exec ts-node -r tsconfig-paths/register --files ./src/app.ts",
-    "start": "NODE_ENV=production pm2 start --name server ts-node -r tsconfig-paths/register --files ./src/app.ts",
+    "start": "NODE_ENV=production pm2 start --name server ts-node -- -r tsconfig-paths/register --files ./src/app.ts",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "prettier": "prettier --write src/**/*.{ts,tsx}"
   },

--- a/src/errors/errorCatchHandler.ts
+++ b/src/errors/errorCatchHandler.ts
@@ -1,10 +1,10 @@
 import { NextFunction } from 'express';
 
 import type {
-  ValidatedRequest,
-  ValidatedRequestHandler,
-  ValidatedResponse,
-  ValidationSchema,
+    ValidatedRequest,
+    ValidatedRequestHandler,
+    ValidatedResponse,
+    ValidationSchema,
 } from '#/types/validation';
 
 /**
@@ -15,7 +15,13 @@ import type {
  */
 
 export const errorCatchHandler =
-  <T extends ValidationSchema>(fn: ValidatedRequestHandler<T>) =>
-  (req: ValidatedRequest<T>, res: ValidatedResponse<T>, next: NextFunction) => {
-    return fn(req, res, next).catch(next);
-  };
+    <T extends ValidationSchema>(
+        fn: ValidatedRequestHandler<T>,
+    ) =>
+    (
+        req: ValidatedRequest<T>,
+        res: ValidatedResponse<T>,
+        next: NextFunction,
+    ) => {
+        return fn(req, res, next).catch(next);
+    };

--- a/src/libs/jsonwebtoken/index.ts
+++ b/src/libs/jsonwebtoken/index.ts
@@ -1,6 +1,7 @@
-import { UnauthorizedError } from '#/errors/definedErrors';
 import dotenv from 'dotenv';
-import jsonwebtoken from 'jsonwebtoken';
+import jsonwebtoken, { type JwtPayload } from 'jsonwebtoken';
+
+import { UnauthorizedError } from '#/errors/definedErrors';
 
 dotenv.config();
 
@@ -34,10 +35,10 @@ export class JsonwebtokenModule {
     /**
      * 인가 받은 JWT 를 검증하여 userId 를 반환하는 함수 verifyJsonWebToken
      */
-    static verifyJsonWebToken(token: string) {
+    static verifyJsonWebToken(token: string): string {
         try {
-            const userId = jsonwebtoken.verify(token, JWT_TOKEN_KEY);
-            return userId || null;
+            const decoded = jsonwebtoken.verify(token, JWT_TOKEN_KEY);
+            return typeof decoded === 'string' ? decoded : decoded.userId;
         } catch (error) {
             throw new UnauthorizedError('인가 받은 토큰이 유효하지 않습니다.');
         }

--- a/src/libs/jsonwebtoken/index.ts
+++ b/src/libs/jsonwebtoken/index.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import jsonwebtoken, { type JwtPayload } from 'jsonwebtoken';
+import jsonwebtoken from 'jsonwebtoken';
 
 import { UnauthorizedError } from '#/errors/definedErrors';
 

--- a/src/libs/jsonwebtoken/index.ts
+++ b/src/libs/jsonwebtoken/index.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from '#/errors/definedErrors';
 import dotenv from 'dotenv';
 import jsonwebtoken from 'jsonwebtoken';
 
@@ -34,7 +35,11 @@ export class JsonwebtokenModule {
      * 인가 받은 JWT 를 검증하여 userId 를 반환하는 함수 verifyJsonWebToken
      */
     static verifyJsonWebToken(token: string) {
-        const userId = jsonwebtoken.verify(token, JWT_TOKEN_KEY);
-        return userId || null;
+        try {
+            const userId = jsonwebtoken.verify(token, JWT_TOKEN_KEY);
+            return userId || null;
+        } catch (error) {
+            throw new UnauthorizedError('인가 받은 토큰이 유효하지 않습니다.');
+        }
     }
 }

--- a/src/middlewares/checkLogin.ts
+++ b/src/middlewares/checkLogin.ts
@@ -20,7 +20,7 @@ export const checkLogin: RequestHandler<
     qs.ParsedQs,
     ResponseLocalQuery
 > = async (req, res, next) => {
-    const accessToken = req.headers.authorization;
+    const accessToken = req.headers.authorization?.split('Bearer ')[1];
 
     if (!accessToken) {
         throw new UnauthorizedError('요청에 사용자 정보가 없습니다.');
@@ -35,10 +35,9 @@ export const checkLogin: RequestHandler<
     const user = await userModel.findOne({ id: userId });
 
     if (!user) {
-        throw new UnauthorizedError('인가 받은 토큰이 유효하지 않습니다.');
+        throw new UnauthorizedError('유효하지 않은 사용자 정보입니다.');
     }
 
     res.locals.userId = userId;
-
     next();
 };

--- a/src/middlewares/checkLogin.ts
+++ b/src/middlewares/checkLogin.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from 'express';
+import { ParamsDictionary } from 'express-serve-static-core';
+import type { JwtPayload } from 'jsonwebtoken';
+
+import { UnauthorizedError } from '#/errors/definedErrors';
+import { JsonwebtokenModule } from '#/libs/jsonwebtoken';
+import { userModel } from '#/models/user';
+
+
+// TODO : res.locals 가 타입 추론이 되도록 이후 미들웨어에서의 제어 필요
+interface ResponseLocalQuery {
+    [key: string]: unknown;
+    userId: string | JwtPayload;
+}
+
+export const checkLogin: RequestHandler<
+    ParamsDictionary,
+    unknown,
+    unknown,
+    qs.ParsedQs,
+    ResponseLocalQuery
+> = async (req, res, next) => {
+    const accessToken = req.headers.authorization;
+
+    if (!accessToken) {
+        throw new UnauthorizedError('요청에 사용자 정보가 없습니다.');
+    }
+
+    const userId = JsonwebtokenModule.verifyJsonWebToken(accessToken);
+
+    if (!userId) {
+        throw new UnauthorizedError('인가 받은 토큰이 유효하지 않습니다.');
+    }
+
+    const user = await userModel.findOne({ id: userId });
+
+    if (!user) {
+        throw new UnauthorizedError('인가 받은 토큰이 유효하지 않습니다.');
+    }
+
+    res.locals.userId = userId;
+
+    next();
+};

--- a/src/models/album/index.ts
+++ b/src/models/album/index.ts
@@ -1,0 +1,1 @@
+export * from './model';

--- a/src/models/album/model.ts
+++ b/src/models/album/model.ts
@@ -1,0 +1,13 @@
+import { type Document, model } from 'mongoose';
+import { SoftDeleteModel } from 'soft-delete-plugin-mongoose';
+
+import { type BaseMethodModel } from '#/libs/mongoose/base-method';
+
+import { type AlbumType, albumSchema } from './schema';
+
+type PluginModel<T extends Document> = BaseMethodModel<T> & SoftDeleteModel<T>;
+
+export const albumModel = model<AlbumType, PluginModel<AlbumType>>(
+    'album',
+    albumSchema,
+);

--- a/src/models/album/schema.ts
+++ b/src/models/album/schema.ts
@@ -1,0 +1,35 @@
+import { Document, Schema } from 'mongoose';
+
+import { mongooseUniqueIdPlugin } from '#/libs/mongoose/unique-id';
+
+export interface AlbumType extends Document {
+    /**
+     * 앨범 Id
+     */
+    id: string;
+    /**
+     * 앨범 소유주 Id
+     */
+    ownerId: string;
+    /**
+     * 앨범 이름
+     */
+    name: string;
+}
+
+export const albumSchema = new Schema<AlbumType>({
+    id: {
+        type: String,
+        unique: true,
+    },
+    ownerId: {
+        type: String,
+        required: true,
+    },
+    name: {
+        type: String,
+        required: true,
+    },
+});
+
+albumSchema.plugin(mongooseUniqueIdPlugin, 'album');

--- a/src/routes/album/album.controller.ts
+++ b/src/routes/album/album.controller.ts
@@ -1,5 +1,3 @@
-import { RequestHandler } from 'express-serve-static-core';
-
 import type { AlbumSchema } from '#/routes/album/album.validation';
 import { AlbumService } from '#/service/album/album.service';
 import { ValidatedRequestHandler } from '#/types/validation';
@@ -65,7 +63,7 @@ export class AlbumController {
         return res.status(200).json({ item });
     };
 
-    static getAlbumList: RequestHandler = async (_, res) => {
+    static getAlbumList: ValidatedRequestHandler = async (_, res) => {
         const { userId } = res.locals;
 
         const items = await AlbumService.getAlbumList({

--- a/src/routes/album/album.controller.ts
+++ b/src/routes/album/album.controller.ts
@@ -1,3 +1,5 @@
+import { RequestHandler } from 'express-serve-static-core';
+
 import type { AlbumSchema } from '#/routes/album/album.validation';
 import { AlbumService } from '#/service/album/album.service';
 import { ValidatedRequestHandler } from '#/types/validation';
@@ -23,7 +25,7 @@ export class AlbumController {
             const { userId } = res.locals;
 
             const deleteResult = await AlbumService.deleteAlbum({
-                ownerId: userId as string,
+                ownerId: userId,
                 albumId,
             });
 
@@ -39,12 +41,37 @@ export class AlbumController {
         const { userId } = res.locals;
 
         const updateResult = await AlbumService.modifyAlbum({
-            ownerId: userId as string,
+            ownerId: userId,
             albumId,
             name,
         });
 
         // NOTE : 업데이트 된 컬렉션이 없다면 No Content (204) 반환
         return res.sendStatus(updateResult ? 200 : 204);
+    };
+
+    static getAlbum: ValidatedRequestHandler<AlbumSchema['getAlbum']> = async (
+        req,
+        res,
+    ) => {
+        const { albumId } = req.params;
+        const { userId } = res.locals;
+
+        const item = await AlbumService.getAlbum({
+            albumId,
+            ownerId: userId,
+        });
+
+        return res.status(200).json({ item });
+    };
+
+    static getAlbumList: RequestHandler = async (_, res) => {
+        const { userId } = res.locals;
+
+        const items = await AlbumService.getAlbumList({
+            ownerId: userId,
+        });
+
+        return res.status(200).json({ items });
     };
 }

--- a/src/routes/album/album.controller.ts
+++ b/src/routes/album/album.controller.ts
@@ -1,0 +1,50 @@
+import type { AlbumSchema } from '#/routes/album/album.validation';
+import { AlbumService } from '#/service/album/album.service';
+import { ValidatedRequestHandler } from '#/types/validation';
+
+export class AlbumController {
+    static postCreateAlbum: ValidatedRequestHandler<
+        AlbumSchema['postCreateAlbum']
+    > = async (req, res) => {
+        const { name } = req.body;
+        const { userId } = res.locals;
+
+        const createdAlbum = await AlbumService.createAlbum({
+            ownerId: userId as string,
+            name,
+        });
+
+        return res.status(201).json({ item: createdAlbum });
+    };
+
+    static deleteAlbum: ValidatedRequestHandler<AlbumSchema['deleteAlbum']> =
+        async (req, res) => {
+            const { albumId } = req.params;
+            const { userId } = res.locals;
+
+            const deleteResult = await AlbumService.deleteAlbum({
+                ownerId: userId as string,
+                albumId,
+            });
+
+            // NOTE : 삭제된 컬렉션이 없다면 No Content (204) 반환
+            return res.sendStatus(deleteResult ? 200 : 204);
+        };
+
+    static patchModifyAlbum: ValidatedRequestHandler<
+        AlbumSchema['patchModifyAlbum']
+    > = async (req, res) => {
+        const { albumId } = req.params;
+        const { name } = req.body;
+        const { userId } = res.locals;
+
+        const updateResult = await AlbumService.modifyAlbum({
+            ownerId: userId as string,
+            albumId,
+            name,
+        });
+
+        // NOTE : 업데이트 된 컬렉션이 없다면 No Content (204) 반환
+        return res.sendStatus(updateResult ? 200 : 204);
+    };
+}

--- a/src/routes/album/album.router.ts
+++ b/src/routes/album/album.router.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+
+import { validateMiddleware } from '#/middlewares/validation';
+import { checkLogin } from '#/middlewares/checkLogin';
+
+import { AlbumController } from './album.controller';
+import { albumSchema } from './album.validation';
+
+export const albumRouter = Router();
+
+albumRouter.post(
+    '/new',
+    checkLogin,
+    validateMiddleware(albumSchema.postCreateAlbum),
+    AlbumController.postCreateAlbum,
+);
+
+albumRouter.delete(
+    '/:albumId',
+    validateMiddleware(albumSchema.deleteAlbum),
+    AlbumController.deleteAlbum,
+);
+
+albumRouter.patch(
+    '/:albumId',
+    validateMiddleware(albumSchema.patchModifyAlbum),
+    AlbumController.patchModifyAlbum,
+)

--- a/src/routes/album/album.router.ts
+++ b/src/routes/album/album.router.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
-import { validateMiddleware } from '#/middlewares/validation';
 import { checkLogin } from '#/middlewares/checkLogin';
+import { validateMiddleware } from '#/middlewares/validation';
 
 import { AlbumController } from './album.controller';
 import { albumSchema } from './album.validation';
@@ -27,4 +27,14 @@ albumRouter.patch(
     checkLogin,
     validateMiddleware(albumSchema.patchModifyAlbum),
     AlbumController.patchModifyAlbum,
-)
+);
+
+albumRouter.get(
+    '/:albumId',
+    checkLogin,
+    validateMiddleware(albumSchema.getAlbum),
+    AlbumController.getAlbum,
+);
+
+albumRouter.get('/list', checkLogin, AlbumController.getAlbumList);
+

--- a/src/routes/album/album.router.ts
+++ b/src/routes/album/album.router.ts
@@ -17,12 +17,14 @@ albumRouter.post(
 
 albumRouter.delete(
     '/:albumId',
+    checkLogin,
     validateMiddleware(albumSchema.deleteAlbum),
     AlbumController.deleteAlbum,
 );
 
 albumRouter.patch(
     '/:albumId',
+    checkLogin,
     validateMiddleware(albumSchema.patchModifyAlbum),
     AlbumController.patchModifyAlbum,
 )

--- a/src/routes/album/album.router.ts
+++ b/src/routes/album/album.router.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 
+import { errorCatchHandler } from '#/errors/errorCatchHandler';
 import { checkLogin } from '#/middlewares/checkLogin';
 import { validateMiddleware } from '#/middlewares/validation';
 
@@ -12,29 +13,32 @@ albumRouter.post(
     '/new',
     checkLogin,
     validateMiddleware(albumSchema.postCreateAlbum),
-    AlbumController.postCreateAlbum,
+    errorCatchHandler(AlbumController.postCreateAlbum),
+);
+
+albumRouter.get(
+    '/list',
+    checkLogin,
+    errorCatchHandler(AlbumController.getAlbumList),
 );
 
 albumRouter.delete(
     '/:albumId',
     checkLogin,
     validateMiddleware(albumSchema.deleteAlbum),
-    AlbumController.deleteAlbum,
+    errorCatchHandler(AlbumController.deleteAlbum),
 );
 
 albumRouter.patch(
     '/:albumId',
     checkLogin,
     validateMiddleware(albumSchema.patchModifyAlbum),
-    AlbumController.patchModifyAlbum,
+    errorCatchHandler(AlbumController.patchModifyAlbum),
 );
 
 albumRouter.get(
     '/:albumId',
     checkLogin,
     validateMiddleware(albumSchema.getAlbum),
-    AlbumController.getAlbum,
+    errorCatchHandler(AlbumController.getAlbum),
 );
-
-albumRouter.get('/list', checkLogin, AlbumController.getAlbumList);
-

--- a/src/routes/album/album.validation.ts
+++ b/src/routes/album/album.validation.ts
@@ -11,6 +11,11 @@ export const albumSchema = {
             albumId: z.string(),
         })
     }),
+    getAlbum: z.object({
+        params: z.object({
+            albumId: z.string(),
+        })
+    }),
     patchModifyAlbum: z.object({
         params: z.object({
             albumId: z.string(),
@@ -24,5 +29,6 @@ export const albumSchema = {
 export type AlbumSchema = {
     postCreateAlbum: z.infer<typeof albumSchema.postCreateAlbum>;
     deleteAlbum: z.infer<typeof albumSchema.deleteAlbum>;
+    getAlbum: z.infer<typeof albumSchema.getAlbum>;
     patchModifyAlbum: z.infer<typeof albumSchema.patchModifyAlbum>;
 };

--- a/src/routes/album/album.validation.ts
+++ b/src/routes/album/album.validation.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const albumSchema = {
+    postCreateAlbum: z.object({
+        body: z.object({
+            name: z.string(),
+        }),
+    }),
+    deleteAlbum: z.object({
+        params: z.object({
+            albumId: z.string(),
+        })
+    }),
+    patchModifyAlbum: z.object({
+        params: z.object({
+            albumId: z.string(),
+        }),
+        body: z.object({
+            name: z.string(),
+        }),
+    }),
+};
+
+export type AlbumSchema = {
+    postCreateAlbum: z.infer<typeof albumSchema.postCreateAlbum>;
+    deleteAlbum: z.infer<typeof albumSchema.deleteAlbum>;
+    patchModifyAlbum: z.infer<typeof albumSchema.patchModifyAlbum>;
+};

--- a/src/routes/album/index.ts
+++ b/src/routes/album/index.ts
@@ -1,0 +1,1 @@
+export * from './album.router';

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -14,7 +14,6 @@ export class AuthController {
 
         // NOTE : 유저 정보가 있다면 로그인을 진행하고, 그렇지 않은 경우 회원가입 진행
         if (user) {
-            console.log(user);
             const { accessToken, refreshToken } = AuthService.login({
                 userId: user.id,
             });

--- a/src/routes/auth/auth.router.ts
+++ b/src/routes/auth/auth.router.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 
+import { errorCatchHandler } from '#/errors/errorCatchHandler';
 import { validateMiddleware } from '#/middlewares/validation';
 
 import { AuthController } from './auth.controller';
@@ -10,5 +11,5 @@ export const authRouter = Router();
 authRouter.post(
     '/login',
     validateMiddleware(authSchema.postLogin),
-    AuthController.postLogin,
+    errorCatchHandler(AuthController.postLogin),
 );

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,23 +1,28 @@
 import { Router } from 'express';
 
-import docsRouter from './docs';
+import { albumRouter } from './album';
 import { authRouter } from './auth';
+import docsRouter from './docs';
 
 const defaultRouter = Router();
 
 const routerList = [
-  {
-    path: '/api-docs',
-    router: docsRouter,
-  },
-  {
-    path: '/auth',
-    router: authRouter,
-  }
+    {
+        path: '/api-docs',
+        router: docsRouter,
+    },
+    {
+        path: '/auth',
+        router: authRouter,
+    },
+    {
+        path: '/album',
+        router: albumRouter,
+    },
 ];
 
 routerList.forEach((route) => {
-  defaultRouter.use(route.path, route.router);
+    defaultRouter.use(route.path, route.router);
 });
 
 export default defaultRouter;

--- a/src/service/album/album.service.ts
+++ b/src/service/album/album.service.ts
@@ -34,7 +34,7 @@ export class AlbumService {
         }
 
         const { deleted } = await albumModel.softDelete({ id: albumId });
-        return !!deleted;
+        return deleted > 0;
     }
 
     static async modifyAlbum({
@@ -53,6 +53,27 @@ export class AlbumService {
             { $set: { name } },
         );
 
-        return !!updatedResult.modifiedCount;
+        return updatedResult.modifiedCount > 0;
+    }
+
+    static async getAlbum({
+        albumId,
+        ownerId,
+    }: AlbumServiceReqParam['getAlbum']) {
+        const ownedAlbum = await albumModel.findOne({ id: albumId, ownerId });
+
+        if (!ownedAlbum) {
+            throw new BadRequestError('존재하지 않는 앨범입니다.');
+        }
+
+        return ownedAlbum;
+    }
+
+    static async getAlbumList({
+        ownerId,
+    }: AlbumServiceReqParam['getAlbumList']) {
+        const ownedAlbumList = await albumModel.find({ ownerId });
+
+        return ownedAlbumList;
     }
 }

--- a/src/service/album/album.service.ts
+++ b/src/service/album/album.service.ts
@@ -1,0 +1,58 @@
+import { BadRequestError, ForbiddenError } from '#/errors/definedErrors';
+import { albumModel } from '#/models/album';
+
+import type { AlbumServiceReqParam } from './type';
+
+export class AlbumService {
+    /**
+     * 새로운 앨범을 생성하는 함수 register
+     */
+    static async createAlbum({
+        ownerId,
+        name,
+    }: AlbumServiceReqParam['createAlbum']) {
+        const ownedAlbumAmount = await albumModel.countDocuments({
+            ownerId,
+        });
+
+        if (ownedAlbumAmount > 3) {
+            throw new ForbiddenError('앨범은 최대 3개까지 생성할 수 있습니다.');
+        }
+
+        const createdAlbum = await albumModel.create({ ownerId, name });
+        return createdAlbum;
+    }
+
+    static async deleteAlbum({
+        albumId,
+        ownerId,
+    }: AlbumServiceReqParam['deleteAlbum']) {
+        const ownedAlbum = await albumModel.findOne({ id: albumId, ownerId });
+
+        if (!ownedAlbum) {
+            throw new BadRequestError('존재하지 않는 앨범입니다.');
+        }
+
+        const { deleted } = await albumModel.softDelete({ id: albumId });
+        return !!deleted;
+    }
+
+    static async modifyAlbum({
+        albumId,
+        ownerId,
+        name,
+    }: AlbumServiceReqParam['modifyAlbum']) {
+        const ownedAlbum = await albumModel.findOne({ id: albumId, ownerId });
+
+        if (!ownedAlbum) {
+            throw new BadRequestError('존재하지 않는 앨범입니다.');
+        }
+
+        const updatedResult = await albumModel.updateOne(
+            { id: albumId },
+            { $set: { name } },
+        );
+
+        return !!updatedResult.modifiedCount;
+    }
+}

--- a/src/service/album/type.ts
+++ b/src/service/album/type.ts
@@ -12,4 +12,11 @@ export type AlbumServiceReqParam = {
         albumId: string;
         name: string;
     }
+    getAlbum: {
+        albumId: string;
+        ownerId: string;
+    }
+    getAlbumList: {
+        ownerId: string;
+    }
 }

--- a/src/service/album/type.ts
+++ b/src/service/album/type.ts
@@ -1,0 +1,15 @@
+export type AlbumServiceReqParam = {
+    createAlbum: {
+        ownerId: string;
+        name: string;
+    }
+    deleteAlbum: {
+        ownerId: string;
+        albumId: string;
+    }
+    modifyAlbum: {
+        ownerId: string;
+        albumId: string;
+        name: string;
+    }
+}

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -2,7 +2,6 @@ import type { NextFunction, Request, Response } from 'express';
 import type {
     ParamsDictionary,
     Query,
-    RequestHandler,
 } from 'express-serve-static-core';
 
 export type PaginatedType<T = unknown> = { page: number; limit: number } & T;
@@ -43,7 +42,7 @@ export type ValidatedResponse<T extends ValidationSchema> = Response<
     ResponseLocalQuery<T>
 >;
 
-export type ValidatedRequestHandler<T extends ValidationSchema> = (
+export type ValidatedRequestHandler<T extends ValidationSchema = ValidationSchema> = (
     req: ValidatedRequest<T>,
     res: ValidatedResponse<T>,
     next: NextFunction,

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -1,45 +1,49 @@
 import type { NextFunction, Request, Response } from 'express';
-import type { ParamsDictionary, Query } from 'express-serve-static-core';
+import type {
+    ParamsDictionary,
+    Query,
+    RequestHandler,
+} from 'express-serve-static-core';
 
 export type PaginatedType<T = unknown> = { page: number; limit: number } & T;
 export interface RequestQuery {
-  [key: string]:
-    | Query[string]
-    | number
-    | number[]
-    | boolean
-    | boolean[]
-    | string
-    | string[]
-    | RequestQuery
-    | RequestQuery[];
+    [key: string]:
+        | Query[string]
+        | number
+        | number[]
+        | boolean
+        | boolean[]
+        | string
+        | string[]
+        | RequestQuery
+        | RequestQuery[];
 }
 
 interface ResponseLocalQuery<T extends ValidationSchema> {
-  [key: string]: unknown;
-  query: T['query'];
+    [key: string]: unknown;
+    query?: T['query'];
 }
 
 export type ValidationSchema = {
-  query?: RequestQuery;
-  params?: ParamsDictionary;
-  body?: Record<string, unknown> | Record<string, unknown>[];
+    query?: RequestQuery;
+    params?: ParamsDictionary;
+    body?: Record<string, unknown> | Record<string, unknown>[];
 };
 
 export type ValidatedRequest<T extends ValidationSchema> = Request<
-  T['params'],
-  unknown,
-  T['body'],
-  T['query']
+    T['params'],
+    unknown,
+    T['body'],
+    T['query']
 >;
 
 export type ValidatedResponse<T extends ValidationSchema> = Response<
-  unknown,
-  ResponseLocalQuery<T>
+    unknown,
+    ResponseLocalQuery<T>
 >;
 
 export type ValidatedRequestHandler<T extends ValidationSchema> = (
-  req: ValidatedRequest<T>,
-  res: ValidatedResponse<T>,
-  next: NextFunction,
+    req: ValidatedRequest<T>,
+    res: ValidatedResponse<T>,
+    next: NextFunction,
 ) => Promise<Response>;

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -22,6 +22,7 @@ export interface RequestQuery {
 interface ResponseLocalQuery<T extends ValidationSchema> {
     [key: string]: unknown;
     query?: T['query'];
+    userId: string;
 }
 
 export type ValidationSchema = {


### PR DESCRIPTION
## Issue 번호
#2 

## 작업 내용
- 앨범 Collection 및 Schema 를 정의하고 관련 로직을 구축합니다.
- 앨범과 관련된 생성, 수정, 삭제 관련 api 를 설계하고 이를 구현합니다.
    - 새로운 앨범 생성
    - 보유한 앨범 삭제
    - 앨범 내 정보 수정
    - 내가 보유한 앨범 목록 열람
    - 특정 ID 를 가진 앨범 열람
- 유저의 로그인 정보를 체크하는 미들웨어 checkLogin 을 구현하였습니다.
- Validation Schema 가 없어도 RequestHandler 가 Type Checking 되도록 코드를 수정했습니다.

## Checklist
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
